### PR TITLE
add package cqcode

### DIFF
--- a/cqcode/README.md
+++ b/cqcode/README.md
@@ -1,0 +1,72 @@
+## CQ码
+
+有关 CQ 码请参考 [酷Q官方CQ码说明](https://d.cqp.me/Pro/CQ码) 以及 [cq-http插件说明](https://cqhttp.cc/docs/3.4/#/CQCode)
+
+解码消息
+
+```go
+func pm(sub_type string, message_id float64, user_id float64, message string, font float64) map[string]interface{} {
+
+	m, err := cqcode.ParseMessage(message)
+	if err != nil {
+		return map[string]interface{}{}
+	}
+
+	for _, seg := range m {
+
+		switch seg.Type {
+		case "image":
+			var image cqcode.Image
+			seg.ParseMedia(&image)
+
+			fmt.Print(image.FileID)
+		}
+
+	}
+	...
+}
+```
+
+编码消息
+
+```go
+...
+	m := cqcode.NewMessage()
+
+	face := cqcode.Face{
+		FaceID: 170,
+	}
+	m.Append(&face)
+
+	// 如果消息上报格式为 string 则转换为 string
+	// 如果为 array 则直接使用 m 即可
+	messageStr := m.CQString()
+...
+```
+
+命令解析
+
+```go
+func pm(sub_type string, message_id float64, user_id float64, message string, font float64) map[string]interface{} {
+
+	// 如果上报格式为 string 可以使用静态方法
+	if !cqcode.IsCommand(m.(string)) {
+		return map[string]interface{}{}
+	}
+	cmd, args := cqcode.Command(m.(string))
+
+	// 或者先解码为 Message
+	m, err := cqcode.ParseMessage(message)
+	if err != nil {
+		return map[string]interface{}{}
+	}
+	if !m.IsCommand() {
+		return map[string]interface{}{}
+	}
+	cmd, args := m.Command()
+
+	// cmd string, args []string
+	// 注意：cmd 和 args 仍然为富媒体，可以使用 ParseMessage 解析
+	...
+}
+```

--- a/cqcode/README.md
+++ b/cqcode/README.md
@@ -49,6 +49,9 @@ func pm(sub_type string, message_id float64, user_id float64, message string, fo
 ```go
 func pm(sub_type string, message_id float64, user_id float64, message string, font float64) map[string]interface{} {
 
+	// 命令必须以 "/" 开头，并且解析时自动去掉 "/"，默认为 false
+	cqcode.StrictCommand = true
+
 	// 如果上报格式为 string 可以使用静态方法
 	if !cqcode.IsCommand(m.(string)) {
 		return map[string]interface{}{}

--- a/cqcode/cqcode.go
+++ b/cqcode/cqcode.go
@@ -113,6 +113,9 @@ func IsCommand(str string) bool {
 }
 
 func Command(str string) (cmd string, args []string) {
+	str = strings.Replace(str, `\\`, `\0x5c`, -1)
+	str = strings.Replace(str, `\"`, `\0x22`, -1)
+	str = strings.Replace(str, `\'`, `\0x27`, -1)
 	strs := regexp.MustCompile(`'.*?'|".*?"|\S*\[CQ:.*?\]\S*|\S+`).FindAllString(str, -1)
 	if len(strs) == 0 || len(strs[0]) == 0 {
 		return
@@ -126,7 +129,11 @@ func Command(str string) (cmd string, args []string) {
 		cmd = strs[0]
 	}
 	for _, arg := range strs[1:] {
-		args = append(args, strings.Trim(arg, "\"'"))
+		arg = strings.Trim(arg, `'"`)
+		arg = strings.Replace(arg, `\0x27`, `'`, -1)
+		arg = strings.Replace(arg, `\0x22`, `"`, -1)
+		arg = strings.Replace(arg, `\0x5c`, `\`, -1)
+		args = append(args, arg)
 	}
 	return
 }

--- a/cqcode/cqcode.go
+++ b/cqcode/cqcode.go
@@ -125,7 +125,9 @@ func Command(str string) (cmd string, args []string) {
 	} else {
 		cmd = strs[0]
 	}
-	args = strs[1:]
+	for _, arg := range strs[1:] {
+		args = append(args, strings.Trim(arg, "\"'"))
+	}
 	return
 }
 

--- a/cqcode/cqcode.go
+++ b/cqcode/cqcode.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 )
 
+var StrictCommand = false
+
 type Message []MessageSegment
 
 type MessageSegment struct {
@@ -104,7 +106,7 @@ func IsCommand(str string) bool {
 	if len(str) == 0 {
 		return false
 	}
-	if str[:1] != "/" {
+	if StrictCommand && str[:1] != "/" {
 		return false
 	}
 	return true
@@ -112,10 +114,17 @@ func IsCommand(str string) bool {
 
 func Command(str string) (cmd string, args []string) {
 	strs := regexp.MustCompile(`'.*?'|".*?"|\S*\[CQ:.*?\]\S*|\S+`).FindAllString(str, -1)
-	if len(strs) == 0 || len(strs[0]) == 0 || strs[0][:1] != "/" {
+	if len(strs) == 0 || len(strs[0]) == 0 {
 		return
 	}
-	cmd = strs[0][1:]
+	if StrictCommand {
+		if strs[0][:1] != "/" {
+			return
+		}
+		cmd = strs[0][1:]
+	} else {
+		cmd = strs[0]
+	}
 	args = strs[1:]
 	return
 }

--- a/cqcode/cqcode.go
+++ b/cqcode/cqcode.go
@@ -67,7 +67,7 @@ func ParseMessageFromString(str string) (Message, error) {
 			seg := MessageSegment{
 				Type: "text",
 				Data: map[string]interface{}{
-					"text": str[i:cqc[0]],
+					"text": DecodeCQCodeText(str[i:cqc[0]]),
 				},
 			}
 			message = append(message, seg)
@@ -84,7 +84,7 @@ func ParseMessageFromString(str string) (Message, error) {
 		seg := MessageSegment{
 			Type: "text",
 			Data: map[string]interface{}{
-				"text": str[i:],
+				"text": DecodeCQCodeText(str[i:]),
 			},
 		}
 		message = append(message, seg)
@@ -181,7 +181,7 @@ func NewMessageSegmentFromCQCode(str string) (MessageSegment, error) {
 			if len(kvstrs) == 0 {
 				continue
 			}
-			seg.Data[kvstrs[0]] = strings.Join(kvstrs[1:], "=")
+			seg.Data[kvstrs[0]] = DecodeCQCodeText(strings.Join(kvstrs[1:], "="))
 		}
 	}
 	return seg, nil

--- a/cqcode/cqcode.go
+++ b/cqcode/cqcode.go
@@ -1,0 +1,404 @@
+package cqcode
+
+import (
+	"strings"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/mitchellh/mapstructure"
+	"regexp"
+)
+
+type Message []MessageSegment
+
+type MessageSegment struct {
+	Type string        `json:"type" cq:"type"`
+	Data CQKeyValueMap `json:"data" cq:"data"`
+}
+
+type CQKeyValueMap map[string]interface{}
+
+func Decode(input, output interface{}) error {
+	config := &mapstructure.DecoderConfig{
+		Metadata:         nil,
+		Result:           output,
+		WeaklyTypedInput: true,
+		TagName:          "cq",
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
+func NewMessage() (Message) {
+	return make(Message, 0)
+}
+
+func ParseMessage(msg interface{}) (Message, error) {
+	switch x := msg.(type) {
+	case string:
+		return ParseMessageFromString(x)
+	default:
+		return ParseMessageFromArray(x)
+	}
+}
+
+func ParseMessageFromArray(msg interface{}) (Message, error) {
+	message := Message{}
+	err := Decode(msg, message)
+	if err != nil {
+		return message, err
+	}
+	return message, nil
+}
+
+func ParseMessageFromString(str string) (Message, error) {
+	message := make(Message, 0)
+	res := regexp.MustCompile(`\[CQ:.*?\]`).FindAllStringSubmatchIndex(str, -1)
+	i := 0
+	for _, cqc := range res {
+		if cqc[0] > i {
+			// There is a text message before this cqc
+			seg := MessageSegment{
+				Type: "text",
+				Data: map[string]interface{}{
+					"text": str[i:cqc[0]],
+				},
+			}
+			message = append(message, seg)
+		}
+		i = cqc[1]
+		seg, err := NewMessageSegmentFromCQCode(str[cqc[0]:cqc[1]])
+		if err != nil {
+			continue
+		}
+		message = append(message, seg)
+	}
+	if len(str) > i {
+		// There is a text message after all cqc
+		seg := MessageSegment{
+			Type: "text",
+			Data: map[string]interface{}{
+				"text": str[i:],
+			},
+		}
+		message = append(message, seg)
+	}
+	return message, nil
+}
+
+func (m *Message) IsCommand() bool {
+	str := m.CQString()
+	return IsCommand(str)
+}
+
+func (m *Message) Command() (cmd string, args []string) {
+	str := m.CQString()
+	return Command(str)
+}
+
+func IsCommand(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+	if str[:1] != "/" {
+		return false
+	}
+	return true
+}
+
+func Command(str string) (cmd string, args []string) {
+	strs := regexp.MustCompile(`'.*?'|".*?"|\S*\[CQ:.*?\]\S*|\S+`).FindAllString(str, -1)
+	if len(strs) == 0 || len(strs[0]) == 0 || strs[0][:1] != "/" {
+		return
+	}
+	cmd = strs[0][1:]
+	args = strs[1:]
+	return
+}
+
+func (m *Message) CQString() string {
+	var str string
+	for _, seg := range *m {
+		str += seg.CQString()
+	}
+	return str
+}
+
+func (m *Message) Append(media Media) error {
+	seg, err := NewMessageSegment(media)
+	if err != nil {
+		return err
+	}
+	*m = append(*m, seg)
+	return nil
+}
+
+func NewMessageSegment(media Media) (MessageSegment, error) {
+	seg := MessageSegment{}
+	seg.Type = media.FunctionName()
+	seg.Data = make(CQKeyValueMap)
+	err := Decode(media, &seg.Data)
+	return seg, err
+}
+
+func NewMessageSegmentFromCQCode(str string) (MessageSegment, error) {
+	seg := MessageSegment{}
+	seg.Data = make(CQKeyValueMap)
+	l := len(str)
+	if l <= 5 || str[:4] != "[CQ:" || str[len(str)-1:] != "]" {
+		err := errors.New("invalid")
+		return seg, err
+	}
+	str = str[4 : len(str)-1]
+	strs := strings.Split(str, ",")
+	for i, v := range strs {
+		if i == 0 {
+			seg.Type = strs[0]
+		} else {
+			kvstrs := strings.Split(v, "=")
+			if len(kvstrs) == 0 {
+				continue
+			}
+			seg.Data[kvstrs[0]] = strings.Join(kvstrs[1:], "=")
+		}
+	}
+	return seg, nil
+}
+
+func (seg *MessageSegment) IsMedia(mediaType string) bool {
+	return seg.Type == mediaType
+}
+
+func (seg *MessageSegment) ParseMedia(media Media) error {
+	err := Decode(seg.Data, media)
+	return err
+}
+
+func (seg *MessageSegment) CQString() string {
+	if seg.Type == "text" {
+		t, ok := seg.Data["text"]
+		if !ok {
+			return ""
+		}
+		text := fmt.Sprint(t)
+		text = EncodeCQText(text)
+		return text
+	}
+	strs := make([]string, 0)
+	strs = append(strs, seg.Type)
+	for k, v := range seg.Data {
+		text := fmt.Sprint(v)
+		text = EncodeCQCodeText(text)
+		kvs := fmt.Sprintf("%s=%s", k, text)
+		strs = append(strs, kvs)
+	}
+	str := strings.Join(strs, ",")
+	str = fmt.Sprintf("[CQ:%s]", str)
+	return str
+}
+
+type Media interface {
+	FunctionName() string // 功能名
+}
+
+type Text struct {
+	Text string `cq:"text"`
+}
+
+func (t *Text) FunctionName() string {
+	return "text"
+}
+
+// Mention @
+type At struct {
+	QQ string `cq:"qq"` // Someone's QQ号, could be "all"
+}
+
+func (a *At) FunctionName() string {
+	return "at"
+}
+
+// QQ表情
+type Face struct {
+	FaceID int `cq:"id"` // 1-170 (旧版), >170 (新表情)
+}
+
+func (f *Face) FunctionName() string {
+	return "face"
+}
+
+// Emoji
+type Emoji struct {
+	EmojiID int `cq:"id"` // Unicode Dec
+}
+
+func (e *Emoji) FunctionName() string {
+	return "emoji"
+}
+
+// 原创表情
+type Bface struct {
+	BfaceID int `cq:"id"`
+}
+
+func (b *Bface) FunctionName() string {
+	return "bface"
+}
+
+// 小表情
+type Sface struct {
+	SfaceID int `cq:"id"`
+}
+
+func (s *Sface) FunctionName() string {
+	return "sface"
+}
+
+// Image
+type Image struct {
+	FileID string `cq:"file"`
+}
+
+func (i *Image) FunctionName() string {
+	return "image"
+}
+
+type Record struct {
+	FileID string `cq:"file"`
+	Magic  bool   `cq:"magic"`
+}
+
+func (r *Record) FunctionName() string {
+	return "record"
+}
+
+const (
+	Rock     = 1
+	Paper    = 2
+	Scissors = 3
+)
+
+// 猜拳魔法表情
+type Rps struct {
+	Type int `cq:"type"`
+}
+
+func (rps *Rps) FunctionName() string {
+	return "rps"
+}
+
+// 掷骰子魔法表情
+type Dice struct {
+	Type int `cq:"type"` // 1-6
+}
+
+func (d *Dice) FunctionName() string {
+	return "dice"
+}
+
+// 戳一戳
+type Shake struct {
+}
+
+func (s *Shake) FunctionName() string {
+	return "shake"
+}
+
+// 音乐
+type Music struct {
+	Type string `cq:"type"` // qq, 163, xiami
+	// non-custom music
+	MusicID string `cq:"id"` // id
+	// custom music
+	ShareURL string `cq:"url"`     // Link open on click
+	AudioURL string `cq:"audio"`   // Link of audio
+	Title    string `cq:"title"`   // Title
+	Content  string `cq:"content"` // Description
+	Image    string `cq:"image"`   // Link of cover image
+}
+
+func (m *Music) FunctionName() string {
+	return "music"
+}
+
+func (m *Music) IsCustomMusic() bool {
+	return m.Type == "custom"
+}
+
+// 分享链接
+type Share struct {
+	URL     string `cq:"url"`
+	Title   string `cq:"title"`   // In 12 words
+	Content string `cq:"content"` // In 30 words
+	Image   string `cq:"image"`   // Link of cover image
+}
+
+func (s *Share) FunctionName() string {
+	return "share"
+}
+
+// 位置
+type Location struct {
+}
+
+func (l *Location) FunctionName() string {
+	return "location"
+}
+
+// 厘米秀
+type Show struct {
+}
+
+func (s *Show) FunctionName() string {
+	return "show"
+}
+
+// 签到
+type Sign struct {
+}
+
+func (s *Sign) FunctionName() string {
+	return "sign"
+}
+
+// 其他富媒体
+type Rich struct {
+}
+
+func (r *Rich) FunctionName() string {
+	return "rich"
+}
+
+func EncodeCQText(str string) string {
+	str = strings.Replace(str, "&", "&amp;", -1)
+	str = strings.Replace(str, "[", "&#91;", -1)
+	str = strings.Replace(str, "]", "&#93;", -1)
+	return str
+}
+
+func DecodeCQText(str string) string {
+	str = strings.Replace(str, "&#93;", "]", -1)
+	str = strings.Replace(str, "&#91;", "[", -1)
+	str = strings.Replace(str, "&amp;", "&", -1)
+	return str
+}
+
+func EncodeCQCodeText(str string) string {
+	str = strings.Replace(str, "&", "&amp;", -1)
+	str = strings.Replace(str, "[", "&#91;", -1)
+	str = strings.Replace(str, "]", "&#93;", -1)
+	str = strings.Replace(str, ",", "&#44;", -1)
+	return str
+}
+
+func DecodeCQCodeText(str string) string {
+	str = strings.Replace(str, "&#44;", ",", -1)
+	str = strings.Replace(str, "&#93;", "]", -1)
+	str = strings.Replace(str, "&#91;", "[", -1)
+	str = strings.Replace(str, "&amp;", "&", -1)
+	return str
+}

--- a/cqcode/cqcode_test.go
+++ b/cqcode/cqcode_test.go
@@ -141,6 +141,8 @@ func TestCommand(t *testing.T) {
 
 	m.Append(&text)
 
+	StrictCommand = true
+
 	if !m.IsCommand() {
 		t.Error("Should be command")
 	}
@@ -151,7 +153,7 @@ func TestCommand(t *testing.T) {
 
 	jsonstr := string(res)
 
-	if cmd == "[CQ:face,id=170]" && jsonstr == `["arg1","'a r g 2'","\"a r g 3\"","argemoji[CQ:emoji,id=10086]","arg5"]` {
+	if cmd == "[CQ:face,id=170]" && jsonstr == `["arg1","a r g 2","a r g 3","argemoji[CQ:emoji,id=10086]","arg5"]` {
 		t.Log("Good command")
 	} else {
 		t.Errorf("Parse command failed: %v", jsonstr)

--- a/cqcode/cqcode_test.go
+++ b/cqcode/cqcode_test.go
@@ -27,7 +27,7 @@ func TestMessageSegment_ParseMedia(t *testing.T) {
 
 func TestParseMessageFromString(t *testing.T) {
 
-	str := "heym[CQ:at,qq=123456][CQ:face,id=14] \nSee this awesome image, [CQ:image,file=1.jpg] Isn't it cool? [CQ:shake]\n"
+	str := "&#91;he&#44;ym[CQ:at,qq=123&#44;456][CQ:face,id=14] \nSee this awesome image, [CQ:image,file=1.jpg] Isn't it cool? [CQ:shake]\n"
 
 	mes, err := ParseMessageFromString(str)
 
@@ -39,7 +39,7 @@ func TestParseMessageFromString(t *testing.T) {
 
 	jsonstr := string(res)
 
-	if string(res) == `[{"type":"text","data":{"text":"heym"}},{"type":"at","data":{"qq":"123456"}},{"type":"face","data":{"id":"14"}},{"type":"text","data":{"text":" \nSee this awesome image, "}},{"type":"image","data":{"file":"1.jpg"}},{"type":"text","data":{"text":" Isn't it cool? "}},{"type":"shake","data":{}},{"type":"text","data":{"text":"\n"}}]` {
+	if string(res) == `[{"type":"text","data":{"text":"[he,ym"}},{"type":"at","data":{"qq":"123,456"}},{"type":"face","data":{"id":"14"}},{"type":"text","data":{"text":" \nSee this awesome image, "}},{"type":"image","data":{"file":"1.jpg"}},{"type":"text","data":{"text":" Isn't it cool? "}},{"type":"shake","data":{}},{"type":"text","data":{"text":"\n"}}]` {
 		t.Log("Decode text passed")
 	} else {
 		t.Errorf("Decode text failed: %v", jsonstr)

--- a/cqcode/cqcode_test.go
+++ b/cqcode/cqcode_test.go
@@ -1,0 +1,160 @@
+package cqcode
+
+import (
+	"testing"
+	"encoding/json"
+)
+
+func TestMessageSegment_ParseMedia(t *testing.T) {
+
+	seg := MessageSegment{
+		Type: "text",
+		Data: map[string]interface{}{
+			"text": "test text message",
+		},
+	}
+
+	var text Text
+	seg.ParseMedia(&text)
+
+	if text.Text == "test text message" {
+		t.Log("Decode text passed")
+	} else {
+		t.Errorf("Decode text failed: %v", text.Text)
+	}
+
+}
+
+func TestParseMessageFromString(t *testing.T) {
+
+	str := "heym[CQ:at,qq=123456][CQ:face,id=14] \nSee this awesome image, [CQ:image,file=1.jpg] Isn't it cool? [CQ:shake]\n"
+
+	mes, err := ParseMessageFromString(str)
+
+	if err != nil {
+		t.Fatalf("Decode text failed: %v", err)
+	}
+
+	res, _ := json.Marshal(mes)
+
+	jsonstr := string(res)
+
+	if string(res) == `[{"type":"text","data":{"text":"heym"}},{"type":"at","data":{"qq":"123456"}},{"type":"face","data":{"id":"14"}},{"type":"text","data":{"text":" \nSee this awesome image, "}},{"type":"image","data":{"file":"1.jpg"}},{"type":"text","data":{"text":" Isn't it cool? "}},{"type":"shake","data":{}},{"type":"text","data":{"text":"\n"}}]` {
+		t.Log("Decode text passed")
+	} else {
+		t.Errorf("Decode text failed: %v", jsonstr)
+	}
+
+}
+
+func TestMessage_Append(t *testing.T) {
+
+	music := Music{
+		Type:     "custom",
+		ShareURL: "http://localhost:8080",
+	}
+
+	m := NewMessage()
+
+	err := m.Append(&music)
+
+	if err != nil {
+		t.Fatalf("Decode text failed: %v", err)
+	}
+
+	res, _ := json.Marshal(m)
+
+	jsonstr := string(res)
+
+	if string(res) == `[{"type":"music","data":{"audio":"","content":"","id":"","image":"","title":"","type":"custom","url":"http://localhost:8080"}}]` {
+		t.Log("Append music passed")
+	} else {
+		t.Errorf("Append music failed: %v", jsonstr)
+	}
+
+}
+
+func TestMessageSegment_CQString(t *testing.T) {
+
+	rec := Record{
+		FileID: "/data/audio/[,]&",
+		Magic:  false,
+	}
+
+	seg, _ := NewMessageSegment(&rec)
+
+	f := seg.CQString()
+
+	shake := Shake{}
+
+	seg, _ = NewMessageSegment(&shake)
+
+	s := seg.CQString()
+
+	text := Text{
+		Text: "[,]&",
+	}
+
+	seg, _ = NewMessageSegment(&text)
+
+	ts := seg.CQString()
+
+	if f == "[CQ:record,file=/data/audio/&#91;&#44;&#93;&amp;,magic=false]" && s == "[CQ:shake]" && ts == "&#91;,&#93;&amp;" {
+		t.Log("Format CQString passed")
+	} else {
+		t.Errorf("Format CQString failed: %v %v %v", f, s, ts)
+	}
+
+}
+
+func TestCommand(t *testing.T) {
+
+	m := NewMessage()
+
+	text := Text{
+		Text: "/",
+	}
+
+	m.Append(&text)
+
+	face := Face{
+		FaceID: 170,
+	}
+
+	m.Append(&face)
+
+	text = Text{
+		Text: ` arg1 'a r g 2' "a r g 3" argemoji`,
+	}
+
+	m.Append(&text)
+
+	emoji := Emoji{
+		EmojiID: 10086,
+	}
+
+	m.Append(&emoji)
+
+	text = Text{
+		Text: ` arg5`,
+	}
+
+	m.Append(&text)
+
+	if !m.IsCommand() {
+		t.Error("Should be command")
+	}
+
+	cmd, args := m.Command()
+
+	res, _ := json.Marshal(args)
+
+	jsonstr := string(res)
+
+	if cmd == "[CQ:face,id=170]" && jsonstr == `["arg1","'a r g 2'","\"a r g 3\"","argemoji[CQ:emoji,id=10086]","arg5"]` {
+		t.Log("Good command")
+	} else {
+		t.Errorf("Parse command failed: %v", jsonstr)
+	}
+
+}

--- a/cqcode/cqcode_test.go
+++ b/cqcode/cqcode_test.go
@@ -124,7 +124,7 @@ func TestCommand(t *testing.T) {
 	m.Append(&face)
 
 	text = Text{
-		Text: ` arg1 'a r g 2' "a r g 3" argemoji`,
+		Text: ` arg1 'a \'r g 2' "a \"r \\\"g 3\\" argemoji`,
 	}
 
 	m.Append(&text)
@@ -153,7 +153,7 @@ func TestCommand(t *testing.T) {
 
 	jsonstr := string(res)
 
-	if cmd == "[CQ:face,id=170]" && jsonstr == `["arg1","a r g 2","a r g 3","argemoji[CQ:emoji,id=10086]","arg5"]` {
+	if cmd == "[CQ:face,id=170]" && jsonstr == `["arg1","a 'r g 2","a \"r \\\"g 3\\","argemoji[CQ:emoji,id=10086]","arg5"]` {
 		t.Log("Good command")
 	} else {
 		t.Errorf("Parse command failed: %v", jsonstr)


### PR DESCRIPTION
原来的 cq 包只能生成 cq 码，不能解析，也不能处理转义
我写了新的 cq 码的 lib，命名为 cqcode，
它
+ 可以自动处理转义
+ 收发消息都可以使用
+ 支持 string 和 array 格式的上报
+ 包含命令解释功能，比起原来不处理 cq 码的简单空格分割，更加强大，如：参数可以为含 emoji 的文本

没写完整测试，测试不一定覆盖的全，可能有 bug
简单使用文档在 https://github.com/rikakomoe/cqhttp-go-sdk/tree/cqcode/cqcode